### PR TITLE
Use «vnu-jar» package instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "async": "^0.9.0",
     "chalk": "^0.4.0",
-    "follow-redirects": "0.0.3"
+    "follow-redirects": "0.0.3",
+    "vnu-jar": "*"
   },
   "keywords": [
     "grunt",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "async": "^0.9.0",
     "chalk": "^0.4.0",
     "follow-redirects": "0.0.3",
-    "vnu-jar": "*"
+    "vnu-jar": "latest"
   },
   "keywords": [
     "grunt",

--- a/tasks/htmllint-http.js
+++ b/tasks/htmllint-http.js
@@ -7,6 +7,7 @@ var spawn   = require('child_process').spawn;
 var async = require('async');
 var http  = require('follow-redirects').http;
 var chalk = require('chalk');
+var jar = require('vnu-jar');
 
 //
 // Create new Grunt multi task
@@ -100,7 +101,7 @@ function _spawnVnu() {
     return spawn('java', [
         '-Xss512k', // sometimes we get *a lot* of output
         '-jar',
-        path.join(__dirname, '../vnu.jar'),
+        jar,
         '--format',
         'json',
         '-'


### PR DESCRIPTION
No longer need to keep the `vnu.jar` file in the repository. Use [vnu-jar](https://www.npmjs.com/package/vnu-jar) package instead. You never have to worry about the fresh version of `vnu.jar`.